### PR TITLE
Fix initial compilation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,8 @@ jobs:
             ${{ matrix.os }}-yarn2-
 
       - run: yarn install --frozen-lockfile --ignore-scripts
-      - run: yarn first
+      - run: yarn clean
+      - run: yarn compile
         env:
           TS_NODE_TRANSPILE_ONLY: 1
       - run: yarn lint

--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ yarn install
 
 ## Building
 
-If it is the first compilation, and only the first time, we need to generate the types first:
-
-```sh
-yarn run first
-```
-
 Compile the smart contracts:
 
 ```sh

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,11 +7,15 @@ import "hardhat-typechain";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
 import "@nomiclabs/hardhat-etherscan";
+import fs from "fs";
+import path from "path";
 
-// Since some tasks depend on compilation artifacts,
-// we skip loading the tasks when compiling
-if (process.argv.indexOf("compile") === -1) {
+if (fs.existsSync(path.join(__dirname, "artifacts/types"))) {
   import("./tasks/index");
+} else {
+  console.warn(
+    "Tasks loading skipped until compilation artifacts are available"
+  );
 }
 
 dotenv.config();

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,8 +8,8 @@ import "hardhat-gas-reporter";
 import "solidity-coverage";
 import "@nomiclabs/hardhat-etherscan";
 
-// Skip tasks loading while compiling, because tasks depend on artifacts created
-// by the compiling process
+// Since some tasks depend on compilation artifacts,
+// we skip loading the tasks when compiling
 if (process.argv.indexOf("compile") === -1) {
   import("./tasks/index");
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,8 +6,13 @@ import { HardhatUserConfig } from "hardhat/config";
 import "hardhat-typechain";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
-import "./tasks/index";
 import "@nomiclabs/hardhat-etherscan";
+
+// Skip tasks loading while compiling, because tasks depend on artifacts created
+// by the compiling process
+if (process.argv.indexOf("compile") === -1) {
+  import("./tasks/index");
+}
 
 dotenv.config();
 const mnemonic = `${

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Bonding system for the Universal Digital Dollar",
   "main": "index.js",
   "scripts": {
-    "first": "npx hardhat clean && TS_NODE_TRANSPILE_ONLY=1 npx hardhat compile",
     "compile": "hardhat compile",
     "test": "npx hardhat test",
     "test:coverage": "npx hardhat coverage",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Bonding system for the Universal Digital Dollar",
   "main": "index.js",
   "scripts": {
+    "clean": "hardhat clean",
     "compile": "hardhat compile",
     "test": "npx hardhat test",
     "test:coverage": "npx hardhat coverage",


### PR DESCRIPTION
I was just [going through the build process to try to streamline it](https://github.com/pavlovcik/uad-ui/issues/7) and I found the repo compilation is broken at the moment for the initial project setup.

The readme says that on first compilation you've gotta run:

```sh
yarn run first
```

Well, if you:

```sh
git clone https://github.com/ubiquity/uad-contracts
cd uad-contracts
yarn install
yarn first
```

You get

```sh
$ npx hardhat clean && TS_NODE_TRANSPILE_ONLY=1 npx hardhat compile
An unexpected error occurred:

tasks/generateBondingMigrationData.ts:5:25 - error TS2307: Cannot find module '../artifacts/types/Bonding' or its corresponding type declarations.

5 import { Bonding } from "../artifacts/types/Bonding";
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error Command failed with exit code 1.
```

This is due to the hardhat tasks depending on the TypeScript types generated by the compilation process on the `/artifacts` folder. However, these types aren't there until you compile it, so we've gotta a chicken-or-the-egg problem.

To solve it, `yarn first` is supposed to turn off TS type checking but it doesn't seem to work. However if you comment out the tasks loading on the Hardhat config:

```ts
// import "./tasks/index";
```

Then you can successfully run

```sh
yarn compile
```

And it works; then you can comment it out again and leave it, since the initial artifacts are there and Hardhat manages to load successfully.

The workaround I figured out is to conditionally load the tasks only if the command is not `compile`

```ts
// Since some tasks depend on compilation artifacts,
// we skip loading the tasks when compiling
if (process.argv.indexOf("compile") === -1) {
  import("./tasks/index");
}
```

And we can remove `yarn first` from the package.json scripts. We don't need to load the tasks for compilation anyway.


